### PR TITLE
fix: use PK-based URLs for scholar detail to prevent wrong profile navigation

### DIFF
--- a/dissdb/models.py
+++ b/dissdb/models.py
@@ -183,7 +183,7 @@ class Scholar(models.Model):
         from django.urls import reverse
 
         name_slug = slugify(f"{self.name_last}-{self.name_first}") or "scholar"
-        return reverse("scholar-detail", kwargs={"slug": name_slug})
+        return reverse("scholar-detail", kwargs={"pk": self.pk, "slug": name_slug})
 
     def __str__(self) -> str:
         return self.name_full_rev

--- a/dissdb/urls.py
+++ b/dissdb/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
         name="committeemembers",
     ),
     # path("dissertations/<int:pk>", views.DissDetailView.as_view(), name="diss-detail"),
-    path("scholar/<slug:slug>/", views.ScholarDetailView.as_view(), name="scholar-detail"),
+    path("scholar/<int:pk>/<slug:slug>/", views.ScholarDetailView.as_view(), name="scholar-detail"),
     path('scholars/', views.FilteredScholarListView.as_view(), name='scholars'),
     path('scholars/create/', views.ScholarCreateView.as_view(), name='scholar-create'),
     path('scholars/api/', views.ScholarListAPI.as_view(), name='scholar-list-api'),

--- a/dissdb/views.py
+++ b/dissdb/views.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.text import slugify
 from django.views import generic
 from django.views.generic.edit import UpdateView
 from django_filters.views import FilterView
@@ -287,13 +286,6 @@ class ScholarDetailView(generic.DetailView):
     model = Scholar
     context_object_name = "scholar_detail"
     template_name = 'dissertations/scholar_detail.html'
-
-    def get_object(self, queryset=None):
-        slug = self.kwargs["slug"]
-        for scholar in Scholar.objects.only("pk", "name_last", "name_first"):
-            if (slugify(f"{scholar.name_last}-{scholar.name_first}") or "scholar") == slug:
-                return Scholar.objects.get(pk=scholar.pk)
-        raise Http404
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Scholars with similar names (e.g. "James Reed" and "James W. Reed") produced identical slugs, causing links to always resolve to the first-created record. Switch to `/scholar/<pk>/<slug>/` URLs so each scholar has a unique, stable URL. This also eliminates the `O(n)` full table scan in `get_object()` — lookups are now a single indexed query.